### PR TITLE
adding support for dynamic data types

### DIFF
--- a/LLDB_Eigen_Data_Formatter.py
+++ b/LLDB_Eigen_Data_Formatter.py
@@ -54,9 +54,15 @@ def format (valobj,internal_dict):
 
     else:
         data = valobj.GetValueForExpressionPath(".m_storage.m_data")
-        rows = valobj.GetValueForExpressionPath(".m_storage.m_rows").GetValueAsSigned()
-        cols = valobj.GetValueForExpressionPath(".m_storage.m_cols").GetValueAsSigned()
-
+        tr = valobj.GetValueForExpressionPath(".m_storage").GetChildMemberWithName('m_rows')
+        tc = valobj.GetValueForExpressionPath(".m_storage").GetChildMemberWithName('m_cols')
+        if tr.IsValid():
+            rows = tr.GetValueAsSigned()
+        if tc.IsValid():
+            cols = tc.GetValueAsUnsigned()
+        else:
+            # object likely a dynamic vector (need at least one column)
+            cols = 1
 
     output = ""
 


### PR DESCRIPTION
@tehrengruber nice script. I needed dynamic size support (#1). 
I tested it with basic types:

```
    Matrix<double, 1, 2> t; t.fill(1);
    Matrix<uint, 2, 2> t2; t2.fill(2);
    MatrixXd t3;  t3.setOnes(3,3);
    Vector3f t4; t4.fill(4);
    Vector3i t5; t5.fill(5);
    VectorXd t6(6); t6.fill(6);
```
Should be working.
(lines 56-58 should have some check for validity)
