### PR TITLE
Python 3 and array support

### DIFF
--- a/LLDB_Eigen_Data_Formatter.py
+++ b/LLDB_Eigen_Data_Formatter.py
@@ -3,6 +3,7 @@ import os
 
 def __lldb_init_module (debugger, dict):
     debugger.HandleCommand("type summary add -x \"Eigen::Matrix\" -F LLDB_Eigen_Data_Formatter.format_matrix")
+    debugger.HandleCommand("type summary add -x \"Eigen::Array\" -F LLDB_Eigen_Data_Formatter.format_matrix")
 
 # Define a context manager to suppress stdout and stderr.
 #  see http://stackoverflow.com/questions/11130156/suppress-stdout-stderr-print-from-python-functions

--- a/LLDB_Eigen_Data_Formatter.py
+++ b/LLDB_Eigen_Data_Formatter.py
@@ -9,7 +9,7 @@ def __lldb_init_module (debugger, dict):
 class suppress_stdout_stderr(object):
     def __init__(self):
         # Open a pair of null files
-        self.null_fds =  [os.open(os.devnull,os.O_RDWR) for x in xrange(2)]
+        self.null_fds =  [os.open(os.devnull,os.O_RDWR) for x in range(2)]
         # Save the actual stdout (1) and stderr (2) file descriptors.
         self.save_fds = (os.dup(1), os.dup(2))
 
@@ -38,15 +38,15 @@ def print_raw_matrix(valobj, rows, cols):
 
     # determine padding
     padding = 1
-    for i in xrange(0, rows*cols):
+    for i in range(0, rows*cols):
         padding = max(padding, len(str(valobj.GetChildAtIndex(i, lldb.eNoDynamicValues, True).GetValue())))
 
     # print values
-    for i in xrange(0,rows):
+    for i in range(0,rows):
         if i!=0:
             output += " "
 
-        for j in xrange(0,cols):
+        for j in range(0,cols):
             val = valobj.GetChildAtIndex(j+i*cols, lldb.eNoDynamicValues, True).GetValue()
             output += val.rjust(padding+1, ' ')
         


### PR DESCRIPTION
`xrange` is not available in Python 3 (`range`) does the same thing.

Also add support for the `Array` type.