### PR TITLE
Fix incorrect storage order

### DIFF
--- a/LLDB_Eigen_Data_Formatter.py
+++ b/LLDB_Eigen_Data_Formatter.py
@@ -3,6 +3,7 @@ import os
 
 def __lldb_init_module (debugger, dict):
     debugger.HandleCommand("type summary add -x \"Eigen::Matrix\" -F LLDB_Eigen_Data_Formatter.format_matrix")
+    debugger.HandleCommand("type summary add -x \"Eigen::Array\" -F LLDB_Eigen_Data_Formatter.format_matrix")
 
 # Define a context manager to suppress stdout and stderr.
 #  see http://stackoverflow.com/questions/11130156/suppress-stdout-stderr-print-from-python-functions

--- a/LLDB_Eigen_Data_Formatter.py
+++ b/LLDB_Eigen_Data_Formatter.py
@@ -9,7 +9,7 @@ def __lldb_init_module (debugger, dict):
 class suppress_stdout_stderr(object):
     def __init__(self):
         # Open a pair of null files
-        self.null_fds =  [os.open(os.devnull,os.O_RDWR) for x in xrange(2)]
+        self.null_fds =  [os.open(os.devnull,os.O_RDWR) for x in range(2)]
         # Save the actual stdout (1) and stderr (2) file descriptors.
         self.save_fds = (os.dup(1), os.dup(2))
 
@@ -38,15 +38,15 @@ def print_raw_matrix(valobj, rows, cols):
 
     # determine padding
     padding = 1
-    for i in xrange(0, rows*cols):
+    for i in range(0, rows*cols):
         padding = max(padding, len(str(valobj.GetChildAtIndex(i, lldb.eNoDynamicValues, True).GetValue())))
 
     # print values
-    for i in xrange(0,rows):
+    for i in range(0,rows):
         if i!=0:
             output += " "
 
-        for j in xrange(0,cols):
+        for j in range(0,cols):
             val = valobj.GetChildAtIndex(j+i*cols, lldb.eNoDynamicValues, True).GetValue()
             output += val.rjust(padding+1, ' ')
         

--- a/README.md
+++ b/README.md
@@ -5,20 +5,21 @@ LLDB Data Formatter for dense matrices and vectors of the [Eigen](http://eigen.t
 ## Example
 
 ```cpp
-Eigen::Matrix<double, 3, 3> A;
-A << 1, 0, 0,
-	 0, 2, 0,
-	 0, 0, 3;
+Eigen::Matrix<double, 3, 4> A;
+A << 1, 2, 3, 4,
+    5, 6, 7, 8,
+    9, 10, 11, 12;
 ```
 
 Corresponding output in LLDB
 
 ```
 (lldb) print A
-(Eigen::Matrix<double, 3, 3, 0, 3, 3>) $11 = rows: 3, cols: 3
-[ 1 0 0;
-  0 2 0;
-  0 0 3 ]
+(Eigen::Matrix<double, 3, 4, 0, 3, 4>) $2 = rows: 3, cols: 4
+[ 1   2   3   4;
+  5   6   7   8;
+  9  10  11  12;
+]
 ```
 
 ## Installation


### PR DESCRIPTION
Default storage order in Eigen is Column-Major, so for example

```
Eigen::Matrix<double, 3, 4> a;
a << 1, 2, 3, 4,
5, 6, 7, 8,
9, 10, 11, 12;
```

prints as
```
(Eigen::Matrix<double, 3, 4, 0, 3, 4>) $2 = rows: 3, cols: 4
[  1  5  9  2;
   6 10  3  7;
  11  4  8 12 ]
```

